### PR TITLE
Spamming Buttons will now not mess the summary.

### DIFF
--- a/frontend/src/components/Incidents.tsx
+++ b/frontend/src/components/Incidents.tsx
@@ -68,7 +68,9 @@ export default function Incidents() {
                   key={id}
                   className="Incident_Button"
                   onClick={() => {
-                    handleClick(incident);
+                    if (!isLoading) {
+                      handleClick(incident);
+                    }
                   }}
                 >
                   {incident.title}


### PR DESCRIPTION
ボタンを連打すると、その分要約する文章に内容が追加されてしまっていた。

要約が出力されるまでボタンを押せないよう変更。